### PR TITLE
move to json column type, allow HTTP POST

### DIFF
--- a/extra_data_schema.sql
+++ b/extra_data_schema.sql
@@ -1,7 +1,7 @@
 CREATE TABLE csa_tests (
     id serial PRIMARY KEY,
     code character varying(50) UNIQUE NOT NULL,
-    extradata jsonb
+    extradata json
 );
 
 ALTER TABLE csa_tests OWNER TO postgres;

--- a/src/main/java/org/openlmis/rearchpoc/RestConfiguration.java
+++ b/src/main/java/org/openlmis/rearchpoc/RestConfiguration.java
@@ -19,6 +19,7 @@ public class RestConfiguration {
         config.addAllowedHeader("*");
         config.addAllowedMethod("GET");
         config.addAllowedMethod("PUT");
+        config.addAllowedMethod("POST");
         source.registerCorsConfiguration("/**", config);
         return new CorsFilter(source);
     }


### PR DESCRIPTION
<img width="607" alt="screen shot 2016-05-03 at 11 20 32 am" src="https://cloud.githubusercontent.com/assets/6156389/14993841/a3052392-1121-11e6-85e0-3a495844d92d.png">

I moved to JSON so I didn't have to upgrade but this shouldn't make a difference to JPA.  I also allowed POST to make it easier to add data.  This seems to work for me for having the Java code be agnostic about extraData.
